### PR TITLE
Add support for field arguments

### DIFF
--- a/lib/graphql/autotest/field.rb
+++ b/lib/graphql/autotest/field.rb
@@ -16,13 +16,17 @@ module GraphQL
       end
 
       private def _to_query
-        return name unless children
-
-        <<~GRAPHQL
-          #{name}#{arguments_to_query} {
-          #{indent(children_to_query, 2)}
-          }
-        GRAPHQL
+        if children
+          <<~GRAPHQL
+            #{name}#{arguments_to_query} {
+            #{indent(children_to_query, 2)}
+            }
+          GRAPHQL
+        elsif arguments && arguments.size > 0
+          "#{name}#{arguments_to_query}"
+        else
+          name
+        end
       end
 
       private def children_to_query


### PR DESCRIPTION
When a field had an argument definition, it was not reflected in the query.
I changed this PR to output the arguments to the query.

### Example:

Schema
```graphql
type Item {
  title(lang: String)
}
type Query {
  item: Item
}
```

Query
```graphql
query sample {
  item {
    # The "lang" argument was not output in previous versions even with ArgumentFetcher specified
    title(lang: "ja")
  }
}
```
